### PR TITLE
Augment the version string, to make it clearer when we're running

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,17 @@
     "default": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc --build .",
-    "postbuild": "prepackage-checks && node --experimental-vm-modules dist/cli.js build",
+    "build": "true // We run tsc in prebuild -> test -> pretest -> buildOnly",
+    "buildOnly": "tsc --build .",
+    "postbuild": "prepackage-checks",
+    "test": "node --experimental-vm-modules dist/cli.js build",
     "lint": "eslint .",
-    "test": "echo 'no tests :('",
     "prebuild": "npm run test",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run buildOnly",
     "lint:fix": "npm run lint -- --fix",
-    "prepublishOnly": "npm run build",
-    "dev": "npm run lint:fix && npm run build"
+    "dev": "npm run lint:fix && npm run build",
+    "clean": "rm -rf build dist",
+    "prepare": "npm run clean && npm run buildOnly"
   },
   "prettier": {
     "semi": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,16 @@ const strip = <T extends VersionSpec>(deps: T): T => {
     ) as T;
 };
 
+function markVersionAsDowngradeBuild(version: string | undefined): string {
+    if (version) {
+        return `${version}-downgraded-build`;
+    }
+    return '0-downgraded-build';
+}
+
 export async function writePackageFile(dir: string) {
     const packageFile = await PACKAGE_JSON;
+    const version = markVersionAsDowngradeBuild(packageFile['version']);
     const dependencies = strip(packageFile.dependencies);
     const devDependencies = strip(packageFile.devDependencies);
     const peerDependencies = strip(packageFile.peerDependencies);
@@ -89,6 +97,7 @@ export async function writePackageFile(dir: string) {
     }
     const packageJson: PackageFile = {
         ...packageFile,
+        version,
         dependencies,
         devDependencies,
         peerDependencies,

--- a/src/package.ts
+++ b/src/package.ts
@@ -25,6 +25,7 @@ type NestedStringRecords =
     | { [s: string]: NestedStringRecords };
 export type PackageFile = Partial<
     Record<string, NestedStringRecords> & {
+        version?: string;
         source: string;
         main: string;
         types: string;


### PR DESCRIPTION
This change is driven by it being difficult to tell within an invocation of npm whether a line of output is part of the outer, main, npm invocation or as a consequence of running downgrade-build.

We also update the scripts to be more similar to prepackage-checks.